### PR TITLE
Develop

### DIFF
--- a/src/main/java/io/grisu/usvcs/rabbitmq/RabbitMQConstants.java
+++ b/src/main/java/io/grisu/usvcs/rabbitmq/RabbitMQConstants.java
@@ -5,7 +5,5 @@ public class RabbitMQConstants {
     public static final String OK = "OK";
     public static final String KO = "KO";
 
-    public static final String RABBITMQ_ERROR_MESSAGE = "rabbitmq_error_message";
-    public static final String RABBITMQ_ERROR_CODE = "rabbitmq_error_code";
     public static final Integer ERROR_CODE = 500;
 }

--- a/src/main/java/io/grisu/usvcs/rabbitmq/ServerRabbitMQ.java
+++ b/src/main/java/io/grisu/usvcs/rabbitmq/ServerRabbitMQ.java
@@ -1,6 +1,7 @@
 package io.grisu.usvcs.rabbitmq;
 
 import com.rabbitmq.client.*;
+import io.grisu.core.GrisuConstants;
 import io.grisu.core.exceptions.GrisuException;
 import io.grisu.core.utils.MapBuilder;
 import io.grisu.pojo.utils.JSONUtils;
@@ -96,8 +97,8 @@ public class ServerRabbitMQ {
                         } else {
                             result = MapBuilder
                                 .instance()
-                                .add(RabbitMQConstants.RABBITMQ_ERROR_MESSAGE, th.toString())
-                                .add(RabbitMQConstants.RABBITMQ_ERROR_CODE, RabbitMQConstants.ERROR_CODE).build();
+                                .add(GrisuConstants.ERROR_MESSAGE, th.toString())
+                                .add(GrisuConstants.ERROR_CODE, RabbitMQConstants.ERROR_CODE).build();
                         }
                     }
 

--- a/src/test/java/io/grisu/usvcs/rabbitmq/ClientServerRabbitMQTest.java
+++ b/src/test/java/io/grisu/usvcs/rabbitmq/ClientServerRabbitMQTest.java
@@ -18,6 +18,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.*;
+
 public class ClientServerRabbitMQTest {
 
     Channel channel;
@@ -48,18 +50,33 @@ public class ClientServerRabbitMQTest {
     }
 
     @Test
-    public void shouldCompleteRoundTripWithCompletableFuture() throws IOException, TimeoutException, InterruptedException {
+    public void shouldCompleteRoundTripWithCompletableFuture() {
         CompletableFuture<String> cf = apiClient.echoService("repeat this");
         Assert.assertEquals(">>>repeat this", cf.join());
     }
 
     @Test
-    public void shouldCompleteExceptionally() throws IOException, TimeoutException, InterruptedException {
+    public void shouldCompleteExceptionally_GrisuException() {
         try {
-            apiClient.errorService(7448).join();
+            apiClient.errorServiceGrisuException(7448).join();
             Assert.fail("Shouldn't pass here");
         } catch (Throwable t) {
             Assert.assertEquals(7448, (int) ((GrisuException) ExceptionUtils.getRootCause(t)).getErrorCode());
+        }
+    }
+
+    @Test
+    public void shouldCompleteExceptionally_NonGrisuException() {
+        try {
+            apiClient.errorServiceNonGrisuException().join();
+            Assert.fail("Shouldn't pass here");
+        } catch (Throwable t) {
+            assertNotNull(t.getCause());
+            Assert.assertEquals(500, (int) ((GrisuException) ExceptionUtils.getRootCause(t)).getErrorCode());
+
+            assertTrue(t.getCause() instanceof GrisuException);
+            GrisuException grisuException = (GrisuException) t.getCause();
+            assertEquals("java.lang.RuntimeException: All Your Base Are Belong To Us", grisuException.getErrorMessage());
         }
     }
 

--- a/src/test/java/io/grisu/usvcs/rabbitmq/supportingclasses/Api.java
+++ b/src/test/java/io/grisu/usvcs/rabbitmq/supportingclasses/Api.java
@@ -11,7 +11,10 @@ public interface Api {
     @NanoService(name = "echo")
     CompletableFuture<String> echoService(String string);
 
-    @NanoService(name = "error")
-    CompletableFuture<String> errorService(Integer errorToReturn);
+    @NanoService(name = "error-grisu")
+    CompletableFuture<String> errorServiceGrisuException(Integer errorToReturn);
+
+    @NanoService(name = "error-non-grisu")
+    CompletableFuture<String> errorServiceNonGrisuException();
 
 }

--- a/src/test/java/io/grisu/usvcs/rabbitmq/supportingclasses/ApiImpl.java
+++ b/src/test/java/io/grisu/usvcs/rabbitmq/supportingclasses/ApiImpl.java
@@ -14,8 +14,12 @@ public class ApiImpl implements Api {
     }
 
     @Override
-    public CompletableFuture<String> errorService(Integer errorToReturn) {
+    public CompletableFuture<String> errorServiceGrisuException(Integer errorToReturn) {
         throw GrisuException.build(MapBuilder.instance().add(GrisuConstants.ERROR_CODE, errorToReturn).build());
     }
 
+    @Override
+    public CompletableFuture<String> errorServiceNonGrisuException() {
+        throw new RuntimeException("All Your Base Are Belong To Us");
+    }
 }

--- a/src/test/java/io/grisu/usvcs/rabbitmq/supportingclasses/ApiStub.java
+++ b/src/test/java/io/grisu/usvcs/rabbitmq/supportingclasses/ApiStub.java
@@ -18,9 +18,14 @@ public class ApiStub extends AbstractStub implements Api {
     }
 
     @Override
-    public CompletableFuture<String> errorService(Integer errorToReturn) {
+    public CompletableFuture<String> errorServiceGrisuException(Integer errorToReturn) {
         return super.call(new Object() {
         }.getClass().getEnclosingMethod(), errorToReturn);
     }
 
+    @Override
+    public CompletableFuture<String> errorServiceNonGrisuException() {
+        return super.call(new Object() {
+        }.getClass().getEnclosingMethod());
+    }
 }


### PR DESCRIPTION
 Use `GrisuConstants` constants in `ServerRabbitMQ` for exception handling

- `GrisuConstants.*` instead of `RabbitMQConstants`
- remove unused constants from `RabbitMQConstants`