### PR TITLE
ServerRabbitMQ: correctly handle async exceptions

### DIFF
--- a/src/main/java/io/grisu/usvcs/rabbitmq/ServerRabbitMQ.java
+++ b/src/main/java/io/grisu/usvcs/rabbitmq/ServerRabbitMQ.java
@@ -3,6 +3,7 @@ package io.grisu.usvcs.rabbitmq;
 import com.rabbitmq.client.*;
 import io.grisu.core.GrisuConstants;
 import io.grisu.core.exceptions.GrisuException;
+import io.grisu.core.utils.ExceptionUtils;
 import io.grisu.core.utils.MapBuilder;
 import io.grisu.pojo.utils.JSONUtils;
 import io.grisu.usvcs.annotations.MicroService;
@@ -92,8 +93,12 @@ public class ServerRabbitMQ {
                             th = e;
                         }
 
+                        Throwable cause = ExceptionUtils.findRootException(th);
+
                         if (th instanceof GrisuException) {
                             result = ((GrisuException) th).serialize();
+                        } else if (cause instanceof GrisuException) {
+                            result = ((GrisuException) cause).serialize();
                         } else {
                             result = MapBuilder
                                 .instance()

--- a/src/test/java/io/grisu/usvcs/rabbitmq/ClientServerRabbitMQTest.java
+++ b/src/test/java/io/grisu/usvcs/rabbitmq/ClientServerRabbitMQTest.java
@@ -66,6 +66,27 @@ public class ClientServerRabbitMQTest {
     }
 
     @Test
+    public void shouldCompleteExceptionally_CompletionExceptionWrappingGrisuException() {
+        try {
+            apiClient.errorServiceCompletionExceptionGrisuException(7448).join();
+            Assert.fail("Shouldn't pass here");
+        } catch (Throwable t) {
+            Assert.assertEquals(7448, (int) ((GrisuException) ExceptionUtils.getRootCause(t)).getErrorCode());
+        }
+    }
+
+    @Test
+    public void shouldCompleteExceptionally_CompletionExceptionWrappingGrisuException_l2() {
+        try {
+            apiClient.errorServiceCompletionExceptionGrisuException_Wrap2(7448).join();
+            Assert.fail("Shouldn't pass here");
+        } catch (Throwable t) {
+            GrisuException grisuException = ((GrisuException) ExceptionUtils.getRootCause(t));
+            Assert.assertEquals(7448, (int) grisuException.getErrorCode());
+        }
+    }
+
+    @Test
     public void shouldCompleteExceptionally_NonGrisuException() {
         try {
             apiClient.errorServiceNonGrisuException().join();

--- a/src/test/java/io/grisu/usvcs/rabbitmq/supportingclasses/Api.java
+++ b/src/test/java/io/grisu/usvcs/rabbitmq/supportingclasses/Api.java
@@ -17,4 +17,10 @@ public interface Api {
     @NanoService(name = "error-non-grisu")
     CompletableFuture<String> errorServiceNonGrisuException();
 
+    @NanoService(name = "error-completion-exception-grisu")
+    CompletableFuture<String> errorServiceCompletionExceptionGrisuException(Integer errorToReturn);
+
+    @NanoService(name = "error-completion-exception-grisu")
+    CompletableFuture<String> errorServiceCompletionExceptionGrisuException_Wrap2(Integer errorToReturn);
+
 }

--- a/src/test/java/io/grisu/usvcs/rabbitmq/supportingclasses/ApiImpl.java
+++ b/src/test/java/io/grisu/usvcs/rabbitmq/supportingclasses/ApiImpl.java
@@ -1,6 +1,7 @@
 package io.grisu.usvcs.rabbitmq.supportingclasses;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 import io.grisu.core.GrisuConstants;
 import io.grisu.core.exceptions.GrisuException;
@@ -21,5 +22,19 @@ public class ApiImpl implements Api {
     @Override
     public CompletableFuture<String> errorServiceNonGrisuException() {
         throw new RuntimeException("All Your Base Are Belong To Us");
+    }
+
+    @Override
+    public CompletableFuture<String> errorServiceCompletionExceptionGrisuException(Integer errorToReturn) {
+        GrisuException grisuException = GrisuException.build(MapBuilder.instance().add(GrisuConstants.ERROR_CODE, errorToReturn).build());
+        throw new CompletionException(grisuException);
+    }
+
+    @Override
+    public CompletableFuture<String> errorServiceCompletionExceptionGrisuException_Wrap2(Integer errorToReturn) {
+        GrisuException grisuException = GrisuException.build(MapBuilder.instance().add(GrisuConstants.ERROR_CODE, errorToReturn).build());
+        CompletionException inner = new CompletionException(grisuException);
+        CompletionException outer = new CompletionException(inner);
+        throw outer;
     }
 }

--- a/src/test/java/io/grisu/usvcs/rabbitmq/supportingclasses/ApiStub.java
+++ b/src/test/java/io/grisu/usvcs/rabbitmq/supportingclasses/ApiStub.java
@@ -28,4 +28,16 @@ public class ApiStub extends AbstractStub implements Api {
         return super.call(new Object() {
         }.getClass().getEnclosingMethod());
     }
+
+    @Override
+    public CompletableFuture<String> errorServiceCompletionExceptionGrisuException(Integer errorToReturn) {
+        return super.call(new Object() {
+        }.getClass().getEnclosingMethod(), errorToReturn);
+    }
+
+    @Override
+    public CompletableFuture<String> errorServiceCompletionExceptionGrisuException_Wrap2(Integer errorToReturn) {
+        return super.call(new Object() {
+        }.getClass().getEnclosingMethod(), errorToReturn);
+    }
 }


### PR DESCRIPTION
- catch and serialize `GrisuExceptions` wrapped in `CompletionException`
- `ExceptionUtils.findRootException()` ensures correct unwrapping (max 3 levels deep as of now)